### PR TITLE
Fixes #7: Replaced parameterless depreceated Handler() constructor.

### DIFF
--- a/app/src/main/java/com/example/jarnetor/Fragments/SplashFrag.kt
+++ b/app/src/main/java/com/example/jarnetor/Fragments/SplashFrag.kt
@@ -2,6 +2,7 @@ package com.example.jarnetor.Fragments
 
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
@@ -22,7 +23,7 @@ class SplashFrag : Fragment() {
         val user = mAuth.currentUser
 
         //If already loggd in, send to initial frag or send to login
-        Handler().postDelayed({
+        Handler(Looper.getMainLooper()).postDelayed({
             if (user != null) {
                 findNavController().navigate(R.id.action_splashFrag_to_subjectFrag)
             } else {


### PR DESCRIPTION
Fixes 1719pankaj#7: Changed parameterless depreceated Handler() constructor to constructor including the Looper.getMainLooper() method.