### PR TITLE
Fixes #9: StartActivityForResult() and onActivityResult() is deprecated.

### DIFF
--- a/app/src/main/java/com/example/jarnetor/Fragments/LoginFrag.kt
+++ b/app/src/main/java/com/example/jarnetor/Fragments/LoginFrag.kt
@@ -1,12 +1,13 @@
 package com.example.jarnetor.Fragments
 
-import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.example.jarnetor.R
 import com.google.android.gms.auth.api.signin.GoogleSignIn
@@ -48,31 +49,30 @@ class LoginFrag : Fragment() {
 
     private fun signIn() {
         val signInIntent = googleSignInClient.signInIntent
-        startActivityForResult(signInIntent, RC_SIGN_IN)
+        startForResult.launch(signInIntent)
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-
-        // Result returned from launching the Intent from GoogleSignInApi.getSignInIntent(...);
-        if (requestCode == RC_SIGN_IN) {
-            val task = GoogleSignIn.getSignedInAccountFromIntent(data)
-            val exception = task.exception
-            if(task.isSuccessful) {
-                try {
-                    // Google Sign In was successful, authenticate with Firebase
-                    val account = task.getResult(ApiException::class.java)!!
-                    Log.d("TAGGER", "firebaseAuthWithGoogle:" + account.id)
-                    firebaseAuthWithGoogle(account.idToken!!)
-                } catch (e: ApiException) {
-                    // Google Sign In failed, update UI appropriately
-                    Log.w("TAGGER", "Google sign in failed", e)
+    private val startForResult =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
+            // Result returned from launching the Intent from GoogleSignInApi.getSignInIntent(...);
+            if (result.resultCode == RC_SIGN_IN) {
+                val task = GoogleSignIn.getSignedInAccountFromIntent(result.data)
+                val exception = task.exception
+                if(task.isSuccessful) {
+                    try {
+                        // Google Sign In was successful, authenticate with Firebase
+                        val account = task.getResult(ApiException::class.java)!!
+                        Log.d("TAGGER", "firebaseAuthWithGoogle:" + account.id)
+                        firebaseAuthWithGoogle(account.idToken!!)
+                    } catch (e: ApiException) {
+                        // Google Sign In failed, update UI appropriately
+                        Log.w("TAGGER", "Google sign in failed", e)
+                    }
+                } else{
+                    Log.w("TAGGER", exception.toString())
                 }
-            } else{
-                Log.w("TAGGER", exception.toString())
             }
         }
-    }
 
     private fun firebaseAuthWithGoogle(idToken: String) {
         val credential = GoogleAuthProvider.getCredential(idToken, null)


### PR DESCRIPTION
StartActivityForResult() and onActivityResult() is deprecated in LoginFrag.kt . So, I simply changed it to registerForActivityResult() method.